### PR TITLE
Version update to resolve security issue in github.com/hashicorp/consul/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module go.guoyk.net/reko
 go 1.12
 
 require (
-	github.com/hashicorp/consul/api v1.1.0
+	github.com/hashicorp/consul/api v1.1.1-0.20190508183408-34eff659dcc5
 	github.com/stretchr/testify v1.3.0
 )


### PR DESCRIPTION
github.com/hashicorp/consul/api v1.1.0 is vulnerable so suggesting to upgrade the version to a secured one. You can check module vulnerability here :
https://search.gocenter.io/github.com~2Fhashicorp~2Fconsul~2Fapi/info?version=v1.1.0

CVE-2020-7219 

HashiCorp Consul and Consul Enterprise up to 1.6.2 HTTP/RPC services allowed unbounded resource usage, and were susceptible to unauthenticated denial of service. Fixed in 1.6.3.
